### PR TITLE
award job reputation per drop completed

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -48,7 +48,7 @@ AddEventHandler('qb-trucker:server:01101110', function(drops)
     local price = (DropPrice * drops) + bonus
     local taxAmount = math.ceil((price / 100) * PaymentTax)
     local payment = price - taxAmount
-    Player.Functions.AddJobReputation(1)
+    Player.Functions.AddJobReputation(drops)
     Player.Functions.AddMoney("bank", payment, "trucker-salary")
     TriggerClientEvent('QBCore:Notify', src, 'You Earned $'..payment, 'success')
 end)


### PR DESCRIPTION
Currently, the job reputation has no meaning, but it should award reputation at least linearly to the number of drops as opposed to 1 point per "shift" done.

This should probably be scaled as the payout bonus is, but for now this is better than a constant 1 rep