### PR TITLE
Add Max Drops

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -18,7 +18,6 @@ local returningToStation = false
 -- Functions
 
 local function returnToStation()
-    JobsDone = 0
     SetBlipRoute(TruckVehBlip, true)
     returningToStation = true
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -337,8 +337,6 @@ local function Deliver()
         ClearPedTasks(PlayerPedId())
         hasBox = false
         currentCount = currentCount + 1
-        
-
         if currentCount == CurrentLocation.dropcount then
             LocationsDone[#LocationsDone+1] = CurrentLocation.id
             TriggerServerEvent("qb-shops:server:RestockShopItems", CurrentLocation.store)
@@ -411,7 +409,6 @@ RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
     PlayerJob = JobInfo
     if OldPlayerJob == "trucker" then
         RemoveTruckerBlips()
-
     elseif PlayerJob.name == "trucker" then
         CreateElements()
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -341,7 +341,7 @@ local function Deliver()
 
         if currentCount == CurrentLocation.dropcount then
             LocationsDone[#LocationsDone+1] = CurrentLocation.id
-            TriggerServerEvent("qb-shops:server:RestockShopItems", CurrentLocation.store) 
+            TriggerServerEvent("qb-shops:server:RestockShopItems", CurrentLocation.store)
             exports['qb-core']:HideText()
             Delivering = false
             showMarker = false

--- a/config.lua
+++ b/config.lua
@@ -4,6 +4,7 @@ Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
 
 Config.BailPrice = 250
 Config.FixedLocation = false
+Config.MaxDrops = 10 -- amount of locations before being forced to return to station to reload
 
 Config.Locations = {
     ["main"] = {

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -27,6 +27,8 @@ local Translations = {
         deliver_box = "Deliver Box Of Products",
         another_box = "Get another Box Of Products",
         goto_next_point = "You Have Delivered All Products, To The Next Point",
+        return_to_station = "You Have Delivered All Products, Return to Station",
+        job_completed = "You Have Completed Your Route, Please Collect Your Pay Cheque"
     },
     info = {
         deliver_e = "~g~E~w~ - Deliver Products",


### PR DESCRIPTION
**Describe Pull request**
Added Max delivery Locations (Drops) Configurable in the config,
Once the maximum number of drops is reached new function return to station is triggered and a blip route is set,
Once returned to the station the blip route is destroyed.

fixes #30

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
