### PR TITLE
fix: properly handle door status when doors are broken off

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -25,7 +25,7 @@ local function returnToStation()
 end
 
 local function hasDoneLocation(locationId)
-    if LocationsDone and table.type(LocationsDone) ~= "empty" then
+    if LocationsDone and table.type(LocationsDone) ~= 'empty' then
         for _, v in pairs(LocationsDone) do
             if v == locationId then
                 return true
@@ -41,7 +41,7 @@ local function getNextLocation()
     if Config.TruckerJobFixedLocation then
         local pos = GetEntityCoords(PlayerPedId(), true)
         local dist = nil
-        for k, v in pairs(Config.TruckerJobLocations["stores"]) do
+        for k, v in pairs(Config.TruckerJobLocations['stores']) do
             local dist2 = #(pos - vector3(v.coords.x, v.coords.y, v.coords.z))
             if dist then
                 if dist2 < dist then
@@ -55,7 +55,7 @@ local function getNextLocation()
         end
     else
         while hasDoneLocation(current) do
-            current = math.random(#Config.TruckerJobLocations["stores"])
+            current = math.random(#Config.TruckerJobLocations['stores'])
         end
     end
 
@@ -101,7 +101,7 @@ local function MenuGarage()
     --    if PlayerData.metadata.jobrep.trucker >= v.jobrep then
     local truckMenu = {
         {
-            header = Lang:t("menu.header"),
+            header = Lang:t('menu.header'),
             isMenuHeader = true
         }
     }
@@ -109,7 +109,7 @@ local function MenuGarage()
         truckMenu[#truckMenu + 1] = {
             header = v.label,
             params = {
-                event = "qb-trucker:client:TakeOutVehicle",
+                event = 'qb-trucker:client:TakeOutVehicle',
                 args = {
                     vehicle = k
                 }
@@ -117,10 +117,10 @@ local function MenuGarage()
         }
     end
     truckMenu[#truckMenu + 1] = {
-        header = Lang:t("menu.close_menu"),
-        txt = "",
+        header = Lang:t('menu.close_menu'),
+        txt = '',
         params = {
-            event = "qb-menu:client:closeMenu"
+            event = 'qb-menu:client:closeMenu'
         }
     }
     exports['qb-menu']:openMenu(truckMenu)
@@ -128,12 +128,12 @@ local function MenuGarage()
 end
 
 local function SetDelivering(active)
-    if PlayerJob.name ~= "trucker" then return end
+    if PlayerJob.name ~= 'trucker' then return end
     Delivering = active
 end
 
 local function ShowMarker(active)
-    if PlayerJob.name ~= "trucker" then return end
+    if PlayerJob.name ~= 'trucker' then return end
     showMarker = active
 end
 
@@ -145,44 +145,44 @@ local function CreateZone(type, number)
     local label
     local size
 
-    if type == "main" then
-        event = "qb-truckerjob:client:PaySlip"
-        label = "Payslip"
+    if type == 'main' then
+        event = 'qb-truckerjob:client:PaySlip'
+        label = 'Payslip'
         coords = vector3(Config.TruckerJobLocations[type].coords.x, Config.TruckerJobLocations[type].coords.y, Config.TruckerJobLocations[type].coords.z)
         heading = Config.TruckerJobLocations[type].coords.h
         boxName = Config.TruckerJobLocations[type].label
         size = 3
-    elseif type == "vehicle" then
-        event = "qb-truckerjob:client:Vehicle"
-        label = "Vehicle"
+    elseif type == 'vehicle' then
+        event = 'qb-truckerjob:client:Vehicle'
+        label = 'Vehicle'
         coords = vector3(Config.TruckerJobLocations[type].coords.x, Config.TruckerJobLocations[type].coords.y, Config.TruckerJobLocations[type].coords.z)
         heading = Config.TruckerJobLocations[type].coords.h
         boxName = Config.TruckerJobLocations[type].label
         size = 10
-    elseif type == "stores" then
-        event = "qb-truckerjob:client:Store"
-        label = "Store"
+    elseif type == 'stores' then
+        event = 'qb-truckerjob:client:Store'
+        label = 'Store'
         coords = vector3(Config.TruckerJobLocations[type][number].coords.x, Config.TruckerJobLocations[type][number].coords.y, Config.TruckerJobLocations[type][number].coords.z)
         heading = Config.TruckerJobLocations[type][number].coords.h
         boxName = Config.TruckerJobLocations[type][number].name
         size = 40
-    elseif type == "line-haul" then
-        event = "qb-truckerjob:client:Line-Haul"
-        label = "Line-Haul"
+    elseif type == 'line-haul' then
+        event = 'qb-truckerjob:client:Line-Haul'
+        label = 'Line-Haul'
         coords = vector3(Config.TruckerJobLocations[type][number].coords.x, Config.TruckerJobLocations[type][number].coords.y, Config.TruckerJobLocations[type][number].coords.z)
         heading = Config.TruckerJobLocations[type][number].coords.h
         boxName = Config.TruckerJobLocations[type][number].name
         size = 40
-    elseif type == "fuel-delivery" then
-        event = "qb-truckerjob:client:Line-Haul"
-        label = "Fuel-Haul"
+    elseif type == 'fuel-delivery' then
+        event = 'qb-truckerjob:client:Line-Haul'
+        label = 'Fuel-Haul'
         coords = vector3(Config.TruckerJobLocations[type][number].coords.x, Config.TruckerJobLocations[type][number].coords.y, Config.TruckerJobLocations[type][number].coords.z)
         heading = Config.TruckerJobLocations[type][number].coords.h
         boxName = Config.TruckerJobLocations[type][number].name
         size = 40
     end
 
-    if Config.UseTarget and type == "main" then
+    if Config.UseTarget and type == 'main' then
         exports['qb-target']:AddBoxZone(boxName, coords, size, size, {
             minZ = coords.z - 5.0,
             maxZ = coords.z + 5.0,
@@ -192,7 +192,7 @@ local function CreateZone(type, number)
         }, {
             options = {
                 {
-                    type = "client",
+                    type = 'client',
                     event = event,
                     label = label,
                 },
@@ -212,24 +212,24 @@ local function CreateZone(type, number)
         zoneCombo = ComboZone:Create({ zone }, { name = boxName, debugPoly = false })
         zoneCombo:onPlayerInOut(function(isPointInside)
             if isPointInside then
-                if type == "main" then
+                if type == 'main' then
                     TriggerEvent('qb-truckerjob:client:PaySlip')
-                elseif type == "vehicle" then
+                elseif type == 'vehicle' then
                     TriggerEvent('qb-truckerjob:client:Vehicle')
-                elseif type == "stores" then
+                elseif type == 'stores' then
                     markerLocation = coords
-                    QBCore.Functions.Notify(Lang:t("mission.store_reached"))
+                    QBCore.Functions.Notify(Lang:t('mission.store_reached'))
                     ShowMarker(true)
                     SetDelivering(true)
                 end
             else
-                if type == "stores" then
+                if type == 'stores' then
                     ShowMarker(false)
                     SetDelivering(false)
                 end
             end
         end)
-        if type == "vehicle" then
+        if type == 'vehicle' then
             local zonedel = BoxZone:Create(
                 coords, 40, 40, {
                     minZ = coords.z - 5.0,
@@ -248,7 +248,7 @@ local function CreateZone(type, number)
                     ShowMarker(false)
                 end
             end)
-        elseif type == "stores" then
+        elseif type == 'stores' then
             CurrentLocation.zoneCombo = zoneCombo
         end
     end
@@ -260,18 +260,18 @@ local function getNewLocation()
         CurrentLocation = {}
         CurrentLocation.id = location
         CurrentLocation.dropcount = math.random(1, 3)
-        CurrentLocation.store = Config.TruckerJobLocations["stores"][location].name
-        CurrentLocation.x = Config.TruckerJobLocations["stores"][location].coords.x
-        CurrentLocation.y = Config.TruckerJobLocations["stores"][location].coords.y
-        CurrentLocation.z = Config.TruckerJobLocations["stores"][location].coords.z
-        CreateZone("stores", location)
+        CurrentLocation.store = Config.TruckerJobLocations['stores'][location].name
+        CurrentLocation.x = Config.TruckerJobLocations['stores'][location].coords.x
+        CurrentLocation.y = Config.TruckerJobLocations['stores'][location].coords.y
+        CurrentLocation.z = Config.TruckerJobLocations['stores'][location].coords.z
+        CreateZone('stores', location)
 
         CurrentBlip = AddBlipForCoord(CurrentLocation.x, CurrentLocation.y, CurrentLocation.z)
         SetBlipColour(CurrentBlip, 3)
         SetBlipRoute(CurrentBlip, true)
         SetBlipRouteColour(CurrentBlip, 3)
     else
-        QBCore.Functions.Notify(Lang:t("success.payslip_time"))
+        QBCore.Functions.Notify(Lang:t('success.payslip_time'))
         if CurrentBlip ~= nil then
             RemoveBlip(CurrentBlip)
             ClearAllBlipRoutes()
@@ -281,28 +281,28 @@ local function getNewLocation()
 end
 
 local function CreateElements()
-    TruckVehBlip = AddBlipForCoord(Config.TruckerJobLocations["vehicle"].coords.x, Config.TruckerJobLocations["vehicle"].coords.y, Config.TruckerJobLocations["vehicle"].coords.z)
+    TruckVehBlip = AddBlipForCoord(Config.TruckerJobLocations['vehicle'].coords.x, Config.TruckerJobLocations['vehicle'].coords.y, Config.TruckerJobLocations['vehicle'].coords.z)
     SetBlipSprite(TruckVehBlip, 326)
     SetBlipDisplay(TruckVehBlip, 4)
     SetBlipScale(TruckVehBlip, 0.6)
     SetBlipAsShortRange(TruckVehBlip, true)
     SetBlipColour(TruckVehBlip, 5)
-    BeginTextCommandSetBlipName("STRING")
-    AddTextComponentSubstringPlayerName(Config.TruckerJobLocations["vehicle"].label)
+    BeginTextCommandSetBlipName('STRING')
+    AddTextComponentSubstringPlayerName(Config.TruckerJobLocations['vehicle'].label)
     EndTextCommandSetBlipName(TruckVehBlip)
 
-    TruckerBlip = AddBlipForCoord(Config.TruckerJobLocations["main"].coords.x, Config.TruckerJobLocations["main"].coords.y, Config.TruckerJobLocations["main"].coords.z)
+    TruckerBlip = AddBlipForCoord(Config.TruckerJobLocations['main'].coords.x, Config.TruckerJobLocations['main'].coords.y, Config.TruckerJobLocations['main'].coords.z)
     SetBlipSprite(TruckerBlip, 479)
     SetBlipDisplay(TruckerBlip, 4)
     SetBlipScale(TruckerBlip, 0.6)
     SetBlipAsShortRange(TruckerBlip, true)
     SetBlipColour(TruckerBlip, 5)
-    BeginTextCommandSetBlipName("STRING")
-    AddTextComponentSubstringPlayerName(Config.TruckerJobLocations["main"].label)
+    BeginTextCommandSetBlipName('STRING')
+    AddTextComponentSubstringPlayerName(Config.TruckerJobLocations['main'].label)
     EndTextCommandSetBlipName(TruckerBlip)
 
-    CreateZone("main")
-    CreateZone("vehicle")
+    CreateZone('main')
+    CreateZone('vehicle')
 end
 
 local function TableCount(tbl)
@@ -330,7 +330,7 @@ end
 local function GetInTrunk()
     local ped = PlayerPedId()
     if IsPedInAnyVehicle(ped, false) then
-        return QBCore.Functions.Notify(Lang:t("error.get_out_vehicle"), "error")
+        return QBCore.Functions.Notify(Lang:t('error.get_out_vehicle'), 'error')
     end
     local pos = GetEntityCoords(ped, true)
     local vehicle = GetVehiclePedIsIn(ped, true)
@@ -338,46 +338,46 @@ local function GetInTrunk()
     local doorStatus = getBackDoorsStatus(vehicle)
 
     if not isTruckerVehicle(vehicle) or CurrentPlate ~= QBCore.Functions.GetPlate(vehicle) then
-        return QBCore.Functions.Notify(Lang:t("error.vehicle_not_correct"), "error")
+        return QBCore.Functions.Notify(Lang:t('error.vehicle_not_correct'), 'error')
     end
 
     if doorStatus == 'CLOSED' then
-        return QBCore.Functions.Notify(Lang:t("error.backdoors_not_open"), "error")
+        return QBCore.Functions.Notify(Lang:t('error.backdoors_not_open'), 'error')
     elseif doorStatus == 'BROKEN' then
         return QBCore.Functions.Notify(Lang:t('error.fix_broken_doors'), 'error')
     end
 
     local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, -2.5, 0)
     if #(pos - vector3(trunkpos.x, trunkpos.y, trunkpos.z)) > Config.TruckerJobVehicles[tv].trunkpos then
-        return QBCore.Functions.Notify(Lang:t("error.too_far_from_trunk"), "error")
+        return QBCore.Functions.Notify(Lang:t('error.too_far_from_trunk'), 'error')
     end
     if isWorking then return end
     isWorking = true
-    QBCore.Functions.Progressbar("work_carrybox", Lang:t("mission.take_box"), 2000, false, true, {
+    QBCore.Functions.Progressbar('work_carrybox', Lang:t('mission.take_box'), 2000, false, true, {
         disableMovement = true,
         disableCarMovement = true,
         disableMouse = false,
         disableCombat = true,
     }, {
-        animDict = "anim@gangops@facility@servers@",
-        anim = "hotwire",
+        animDict = 'anim@gangops@facility@servers@',
+        anim = 'hotwire',
         flags = 16,
     }, {}, {}, function() -- Done
         isWorking = false
-        StopAnimTask(ped, "anim@gangops@facility@servers@", "hotwire", 1.0)
+        StopAnimTask(ped, 'anim@gangops@facility@servers@', 'hotwire', 1.0)
         hasBox = true
     end, function() -- Cancel
         isWorking = false
-        StopAnimTask(ped, "anim@gangops@facility@servers@", "hotwire", 1.0)
-        QBCore.Functions.Notify(Lang:t("error.cancelled"), "error")
+        StopAnimTask(ped, 'anim@gangops@facility@servers@', 'hotwire', 1.0)
+        QBCore.Functions.Notify(Lang:t('error.cancelled'), 'error')
     end)
 end
 
 local function Deliver()
     isWorking = true
     Wait(500)
-    TaskStartScenarioInPlace(PlayerPedId(), "PROP_HUMAN_BUM_BIN", 0, true)
-    QBCore.Functions.Progressbar("work_dropbox", Lang:t("mission.deliver_box"), 2000, false, true, {
+    TaskStartScenarioInPlace(PlayerPedId(), 'PROP_HUMAN_BUM_BIN', 0, true)
+    QBCore.Functions.Progressbar('work_dropbox', Lang:t('mission.deliver_box'), 2000, false, true, {
         disableMovement = true,
         disableCarMovement = true,
         disableMouse = false,
@@ -389,7 +389,7 @@ local function Deliver()
         currentCount = currentCount + 1
         if currentCount == CurrentLocation.dropcount then
             LocationsDone[#LocationsDone + 1] = CurrentLocation.id
-            TriggerServerEvent("qb-shops:server:RestockShopItems", CurrentLocation.store)
+            TriggerServerEvent('qb-shops:server:RestockShopItems', CurrentLocation.store)
             exports['qb-core']:HideText()
             Delivering = false
             showMarker = false
@@ -404,19 +404,19 @@ local function Deliver()
             currentCount = 0
             JobsDone = JobsDone + 1
             if JobsDone == Config.TruckerJobMaxDrops then
-                QBCore.Functions.Notify(Lang:t("mission.return_to_station"))
+                QBCore.Functions.Notify(Lang:t('mission.return_to_station'))
                 returnToStation()
             else
-                QBCore.Functions.Notify(Lang:t("mission.goto_next_point"))
+                QBCore.Functions.Notify(Lang:t('mission.goto_next_point'))
                 getNewLocation()
             end
         else
-            QBCore.Functions.Notify(Lang:t("mission.another_box"))
+            QBCore.Functions.Notify(Lang:t('mission.another_box'))
         end
     end, function() -- Cancel
         isWorking = false
         ClearPedTasks(PlayerPedId())
-        QBCore.Functions.Notify(Lang:t("error.cancelled"), "error")
+        QBCore.Functions.Notify(Lang:t('error.cancelled'), 'error')
     end)
 end
 
@@ -430,7 +430,7 @@ AddEventHandler('onResourceStart', function(resource)
     hasBox = false
     isWorking = false
     JobsDone = 0
-    if PlayerJob.name ~= "trucker" then return end
+    if PlayerJob.name ~= 'trucker' then return end
     CreateElements()
 end)
 
@@ -441,7 +441,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     hasBox = false
     isWorking = false
     JobsDone = 0
-    if PlayerJob.name ~= "trucker" then return end
+    if PlayerJob.name ~= 'trucker' then return end
     CreateElements()
     TriggerServerEvent('qb-shops:server:SetShopList')
 end)
@@ -458,23 +458,23 @@ end)
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
     local OldPlayerJob = PlayerJob.name
     PlayerJob = JobInfo
-    if OldPlayerJob == "trucker" then
+    if OldPlayerJob == 'trucker' then
         RemoveTruckerBlips()
         zoneCombo:destroy()
         exports['qb-core']:HideText()
         Delivering = false
         showMarker = false
-    elseif PlayerJob.name == "trucker" then
+    elseif PlayerJob.name == 'trucker' then
         CreateElements()
     end
 end)
 
 RegisterNetEvent('qb-trucker:client:SpawnVehicle', function()
     local vehicleInfo = selectedVeh
-    local coords = Config.TruckerJobLocations["vehicle"].coords
+    local coords = Config.TruckerJobLocations['vehicle'].coords
     QBCore.Functions.TriggerCallback('QBCore:Server:SpawnVehicle', function(netId)
         local veh = NetToVeh(netId)
-        SetVehicleNumberPlateText(veh, "TRUK" .. tostring(math.random(1000, 9999)))
+        SetVehicleNumberPlateText(veh, 'TRUK' .. tostring(math.random(1000, 9999)))
         SetEntityHeading(veh, coords.w)
         SetVehicleLivery(veh, 1)
         SetVehicleColours(veh, 122, 122)
@@ -482,7 +482,7 @@ RegisterNetEvent('qb-trucker:client:SpawnVehicle', function()
         exports['qb-menu']:closeMenu()
         TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
         SetEntityAsMissionEntity(veh, true, true)
-        TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
+        TriggerEvent('vehiclekeys:client:SetOwner', QBCore.Functions.GetPlate(veh))
         SetVehicleEngineOn(veh, true, true)
         CurrentPlate = QBCore.Functions.GetPlate(veh)
         getNewLocation()
@@ -509,13 +509,13 @@ RegisterNetEvent('qb-truckerjob:client:Vehicle', function()
                 if returningToStation or CurrentLocation then
                     ClearAllBlipRoutes()
                     returningToStation = false
-                    QBCore.Functions.Notify(Lang:t("mission.job_completed"), "success")
+                    QBCore.Functions.Notify(Lang:t('mission.job_completed'), 'success')
                 end
             else
-                QBCore.Functions.Notify(Lang:t("error.vehicle_not_correct"), 'error')
+                QBCore.Functions.Notify(Lang:t('error.vehicle_not_correct'), 'error')
             end
         else
-            QBCore.Functions.Notify(Lang:t("error.no_driver"))
+            QBCore.Functions.Notify(Lang:t('error.no_driver'))
         end
     else
         MenuGarage()
@@ -524,9 +524,9 @@ end)
 
 RegisterNetEvent('qb-truckerjob:client:PaySlip', function()
     if JobsDone > 0 then
-        TriggerServerEvent("qb-trucker:server:01101110", JobsDone)
+        TriggerServerEvent('qb-trucker:server:01101110', JobsDone)
         JobsDone = 0
-        if #LocationsDone == #Config.TruckerJobLocations["stores"] then
+        if #LocationsDone == #Config.TruckerJobLocations['stores'] then
             LocationsDone = {}
         end
         if CurrentBlip ~= nil then
@@ -535,12 +535,12 @@ RegisterNetEvent('qb-truckerjob:client:PaySlip', function()
             CurrentBlip = nil
         end
     else
-        QBCore.Functions.Notify(Lang:t("error.no_work_done"), "error")
+        QBCore.Functions.Notify(Lang:t('error.no_work_done'), 'error')
     end
 end)
 
 RegisterNetEvent('qb-truckerjob:client:SetShopList', function(shoplist)
-    Config.TruckerJobLocations["stores"] = shoplist
+    Config.TruckerJobLocations['stores'] = shoplist
 end)
 -- Threads
 CreateThread(function()
@@ -562,7 +562,7 @@ CreateThread(function()
                     if #(GetEntityCoords(PlayerPedId()) - markerLocation) < 5 then
                         Deliver()
                     else
-                        QBCore.Functions.Notify(Lang:t("error.too_far_from_delivery"), "error")
+                        QBCore.Functions.Notify(Lang:t('error.too_far_from_delivery'), 'error')
                     end
                 end
             end

--- a/config.lua
+++ b/config.lua
@@ -10,58 +10,58 @@ Config.TruckerJobBonus = 20 -- this is a percentage to calculate bonus over 5 de
 Config.TruckerJobPaymentTax = 15
 
 Config.TruckerJobLocations = {
-    ["main"] = {
-        label = "Truck Shed",
+    ['main'] = {
+        label = 'Truck Shed',
         coords = vector4(153.68, -3211.88, 5.91, 274.5),
     },
-    ["vehicle"] = {
-        label = "Truck Storage",
+    ['vehicle'] = {
+        label = 'Truck Storage',
         coords = vector4(141.12, -3204.31, 5.85, 267.5),
     },
 }
 
 Config.TruckerJobVehicles = {
-    ["rumpo"] = {
-        ["label"] = "Rumpo Delivery Van",
-        ["cargodoors"] = {
+    ['rumpo'] = {
+        ['label'] = 'Rumpo Delivery Van',
+        ['cargodoors'] = {
             [0] = 2,
             [1] = 3
         },
-        ["trunkpos"] = 1.5
+        ['trunkpos'] = 1.5
     },
-    ["benson"] = {
-        ["label"] = "Benson Box Truck",
-        ["jobrep"] = 0,
-        ["cargodoors"] = {
+    ['benson'] = {
+        ['label'] = 'Benson Box Truck',
+        ['jobrep'] = 0,
+        ['cargodoors'] = {
             [0] = 5
         },
-        ["trunkpos"] = 3
+        ['trunkpos'] = 3
     },
-    ["mule5"] = {
-        ["label"] = "Mule Box Truck",
-        ["jobrep"] = 0,
-        ["cargodoors"] = {
+    ['mule5'] = {
+        ['label'] = 'Mule Box Truck',
+        ['jobrep'] = 0,
+        ['cargodoors'] = {
             [0] = 2,
             [1] = 3
         },
-        ["trunkpos"] = 1.5
+        ['trunkpos'] = 1.5
     },
-    ["pounder"] = {
-        ["label"] = "Pounder Box Truck",
-        ["jobrep"] = 0,
-        ["cargodoors"] = {
+    ['pounder'] = {
+        ['label'] = 'Pounder Box Truck',
+        ['jobrep'] = 0,
+        ['cargodoors'] = {
             [0] = 2,
             [1] = 3
         },
-        ["trunkpos"] = 7
+        ['trunkpos'] = 7
     },
-    ["boxville4"] = {
-        ["label"] = "Boxville StepVan",
-        ["jobrep"] = 0,
-        ["cargodoors"] = {
+    ['boxville4'] = {
+        ['label'] = 'Boxville StepVan',
+        ['jobrep'] = 0,
+        ['cargodoors'] = {
             [0] = 2,
             [1] = 3
         },
-        ["trunkpos"] = 1.5
+        ['trunkpos'] = 1.5
     },
 }

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -8,7 +8,8 @@ local Translations = {
         backdoors_not_open = "The backdoors of the vehicle aren't open",
         get_out_vehicle = "You need to step out of the vehicle to perform this action",
         too_far_from_trunk = "You need to grab the boxes from the trunk of your vehicle",
-        too_far_from_delivery = "You need to be closer to the delivery point"
+        too_far_from_delivery = "You need to be closer to the delivery point",
+        fix_broken_doors = "You've lost the packages, fix broken doors in order to continue working!"
     },
     success = {
         paid_with_cash = "$%{value} Deposit Paid With Cash",

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -8,7 +8,8 @@ local Translations = {
         backdoors_not_open = "Les portes arrière ne sont pas ouvertes",
         get_out_vehicle = "Vous devez sortir du véhicule",
         too_far_from_trunk = "Vous devez prendre les boites dans le coffre du véhicule",
-        too_far_from_delivery = "Vous être trop loin du point de livraison"
+        too_far_from_delivery = "Vous être trop loin du point de livraison",
+        fix_broken_doors = "Vous avez perdu les colis, réparez les portes cassées afin de continuer à travailler!"
     },
     success = {
         paid_with_cash = "$%{value} Depôt payé avec l'argent",


### PR DESCRIPTION
Fixes #55 

Prioritizes checking for broken doors before assessing their status as open, ensuring players are notified to repair any broken doors before continuing work

+ changed string quotes from " to ' ensuring consistency


- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
